### PR TITLE
Reject path-traversal entries during archive extraction

### DIFF
--- a/cmd/doDeploys.go
+++ b/cmd/doDeploys.go
@@ -187,6 +187,13 @@ func extractTarFile(header *tar.Header, tarReader *tar.Reader, destDir string) e
 	// Prepare the destination path
 	destPath := filepath.Join(destDir, header.Name)
 
+	// Guard against path traversal (Zip Slip): a malicious archive entry such as
+	// "../../etc/cron.d/x" must not be allowed to write outside destDir.
+	rel, err := filepath.Rel(destDir, destPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("illegal path in archive: %s", header.Name)
+	}
+
 	// Handle different types of files
 	switch header.Typeflag {
 	case tar.TypeDir:

--- a/cmd/doDeploys_test.go
+++ b/cmd/doDeploys_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"io"
 	"os"
 	"os/exec"
@@ -129,6 +131,61 @@ func TestUnzipFile(t *testing.T) {
 	}
 	if string(content) != "subfile content" {
 		t.Fatalf("Extracted subfile has wrong content: expected 'subfile content', got '%s'", string(content))
+	}
+}
+
+func TestUnzipFileRejectsPathTraversal(t *testing.T) {
+	// A malicious archive whose entry name escapes the destination directory
+	// (Zip Slip) must be rejected rather than written outside destDir.
+	tempDir, err := os.MkdirTemp("", "slarty-zipslip-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Build a tar.gz with a single entry named "../escaped.txt".
+	tarGzPath := filepath.Join(tempDir, "evil.tar.gz")
+	f, err := os.Create(tarGzPath)
+	if err != nil {
+		t.Fatalf("Failed to create tar.gz: %v", err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	payload := []byte("pwned")
+	hdr := &tar.Header{
+		Name:     "../escaped.txt",
+		Mode:     0644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("Failed to write tar header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("Failed to write tar payload: %v", err)
+	}
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	// Extract into a nested directory so an unguarded "../" would land in tempDir.
+	destDir := filepath.Join(tempDir, "dest")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("Failed to create dest directory: %v", err)
+	}
+
+	err = unzipFile(tarGzPath, destDir)
+	if err == nil {
+		t.Fatal("expected unzipFile to reject path-traversal entry, got nil error")
+	}
+	if !strings.Contains(err.Error(), "illegal path in archive") {
+		t.Errorf("expected illegal-path error, got: %v", err)
+	}
+
+	// The escaped file must not exist outside the destination directory.
+	escaped := filepath.Join(tempDir, "escaped.txt")
+	if _, statErr := os.Stat(escaped); !os.IsNotExist(statErr) {
+		t.Errorf("path traversal succeeded: file written outside destination at %s", escaped)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a **Zip Slip / path traversal** vulnerability in archive extraction.

`extractTarFile` joined the destination directory with the tar entry name without verifying the result stayed inside the destination:

```go
destPath := filepath.Join(destDir, header.Name)
```

A malicious artifact or asset tarball with an entry like `../../etc/cron.d/x` (or a path into `~/.ssh/`) could write files **outside** the deploy location. This affected both `do-deploys` and `deploy-assets`, since both extract through `unzipFile`. Because artifacts are pulled from a shared S3/local repository, anyone able to write to that repository could achieve arbitrary file writes on every deploy host.

## Changes

- `cmd/doDeploys.go`: validate that each extracted path resolves within the destination directory (via `filepath.Rel`) and return an error otherwise.
- `cmd/doDeploys_test.go`: add `TestUnzipFileRejectsPathTraversal`, which builds a tarball containing a `../escaped.txt` entry and asserts extraction fails and nothing is written outside the destination.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes (new regression test included)

Closes #10