### PR TITLE
Print artifact tables in config order

### DIFF
--- a/cmd/artifactNames.go
+++ b/cmd/artifactNames.go
@@ -85,8 +85,8 @@ func runArtifactNames(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(w, " %s \t %s \n", "Application", "Artifact Name")
 	fmt.Fprintf(w, separator)
 
-	for name := range artifactNames {
-		fmt.Fprintf(w, " "+name+"\t "+artifactNames[name]+"\n")
+	for _, artifact := range artifacts {
+		fmt.Fprintf(w, " "+artifact.Name+"\t "+artifactNames[artifact.Name]+"\n")
 	}
 
 	fmt.Fprintf(w, separator)

--- a/cmd/artifactNames_test.go
+++ b/cmd/artifactNames_test.go
@@ -41,6 +41,105 @@ func TestArtifactNamesCommandFlags(t *testing.T) {
 	}
 }
 
+func TestRunArtifactNamesPreservesConfigOrder(t *testing.T) {
+	// Regression test for non-deterministic table ordering: rows must appear in
+	// the same order as the artifacts are defined in the config, not in random
+	// map-iteration order. Several artifacts in non-alphabetical order make a
+	// regression (random ordering) reliably detectable.
+	tempDir, err := os.MkdirTemp("", "slarty-artifact-names-order-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	order := []string{"zebra", "apple", "mango", "delta", "kiwi", "bravo"}
+
+	var artifactsJSON strings.Builder
+	for i, name := range order {
+		if i > 0 {
+			artifactsJSON.WriteString(",")
+		}
+		artifactsJSON.WriteString(`{
+			"name": "` + name + `",
+			"directories": ["` + name + `"],
+			"command": "make ` + name + `",
+			"output_directory": "build/` + name + `",
+			"deploy_location": "deploy/` + name + `",
+			"artifact_prefix": "` + name + `"
+		}`)
+	}
+
+	jsonContent := `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": { "adapter": "Local", "options": { "root": "/tmp/repo" } },
+		"artifacts": [` + artifactsJSON.String() + `]
+	}`
+
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	if err := os.WriteFile(configPath, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	// Initialize a git repository with a directory per artifact.
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test User")
+	for _, name := range order {
+		dirPath := filepath.Join(tempDir, name)
+		if err := os.Mkdir(dirPath, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dirPath, "test.txt"), []byte(name), 0644); err != nil {
+			t.Fatalf("Failed to create file in %s: %v", name, err)
+		}
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "Initial commit")
+
+	oldArtifactsJson := artifactsJson
+	defer func() { artifactsJson = oldArtifactsJson }()
+	artifactsJson = configPath
+
+	oldFilter := filter
+	defer func() { filter = oldFilter }()
+	filter = ""
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	runArtifactNames(&cobra.Command{Use: "test"}, []string{})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// Each name must appear, and in the configured order.
+	lastIdx := -1
+	for _, name := range order {
+		idx := strings.Index(output, name)
+		if idx == -1 {
+			t.Fatalf("Expected output to contain %q, got:\n%s", name, output)
+		}
+		if idx < lastIdx {
+			t.Errorf("Artifact %q appeared out of config order in output:\n%s", name, output)
+		}
+		lastIdx = idx
+	}
+}
+
 func TestRunArtifactNames(t *testing.T) {
 	// Create a temporary directory for testing
 	tempDir, err := os.MkdirTemp("", "slarty-artifact-names-test")

--- a/cmd/hashApplication.go
+++ b/cmd/hashApplication.go
@@ -82,8 +82,8 @@ func runHashApplication(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(w, " %s \t %s \n", "Application", "Hash")
 	fmt.Fprintf(w, separator)
 
-	for name := range artifactHashes {
-		fmt.Fprintf(w, " "+name+"\t "+artifactHashes[name]+"\n")
+	for _, artifact := range artifacts {
+		fmt.Fprintf(w, " "+artifact.Name+"\t "+artifactHashes[artifact.Name]+"\n")
 	}
 
 	fmt.Fprintf(w, separator)


### PR DESCRIPTION
## Summary

`artifact-names` and `hash-application` built a map of results and then ranged over the map to print rows:

```go
for name := range artifactNames {
```

Go randomizes map iteration order, so the output rows came out in a different order on every invocation and did not match the order artifacts are defined in the config (nor the README examples). `should-build` already does this correctly by ranging over the artifacts slice.

## Changes

- `cmd/artifactNames.go` and `cmd/hashApplication.go`: iterate the `artifacts` slice (config order) and look up the result map, instead of ranging the map.
- `cmd/artifactNames_test.go`: add `TestRunArtifactNamesPreservesConfigOrder`, which defines several artifacts in non-alphabetical order and asserts the output rows preserve config order. Verified this test fails against the old map-iteration code and passes with the fix.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes

Closes #13