### PR TITLE
Use tar.gz terminology consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ In the example above, the artifacts for the `Models` and `AMess` applications al
 
 ### slarty do-builds
 
-The `do-builds` command, like most above also accepts the `[-c|--config]` and `[-f|--filter]`. It also accepts a `--force` option. Running `do-builds` will determine the name of the artifact that should result from a build. If it exists in the repo, then it will not be executed. If it does not exist, then the `command` part of the artifacts configuration will be executed. Once the build succeeds, the archive will be created by zipping the `output_directory` into an archive named like what you'd see in the `artifact-names` command. It then stores that archive in the repository.
+The `do-builds` command, like most above also accepts the `[-c|--config]` and `[-f|--filter]`. It also accepts a `--force` option. Running `do-builds` will determine the name of the artifact that should result from a build. If it exists in the repo, then it will not be executed. If it does not exist, then the `command` part of the artifacts configuration will be executed. Once the build succeeds, the archive will be created as a tar.gz of the `output_directory`, named like what you'd see in the `artifact-names` command. It then stores that archive in the repository.
 
 If you provide the `--force` option, then it will not check if the archive exists in the repository. It will build and store the result in the repository which means if it did exist, it will be overwritten. If the build process changed but the code did not, this would be a good way to ensure that the proper artifact archive is what is stored in the repo.
 

--- a/cmd/deployAssets.go
+++ b/cmd/deployAssets.go
@@ -127,7 +127,7 @@ func runDeployAssets(cmd *cobra.Command, args []string) {
 		}
 
 		// Extract the asset to the deploy location
-		err = unzipFile(tempFilePath, deployPath)
+		err = extractTarGz(tempFilePath, deployPath)
 		if err != nil {
 			os.Remove(tempFilePath)
 			log.Fatalf("Failed to extract asset: %v", err)

--- a/cmd/doBuilds.go
+++ b/cmd/doBuilds.go
@@ -149,7 +149,7 @@ func runDoBuilds(cmd *cobra.Command, args []string) {
 		tempTarGzFile.Close() // Close the file so we can reopen it for archiving
 
 		// Archive the output directory
-		err = zipDirectory(filepath.Join(artifactConfig.RootDirectory, artifact.OutputDirectory), tempTarGzPath)
+		err = createTarGz(filepath.Join(artifactConfig.RootDirectory, artifact.OutputDirectory), tempTarGzPath)
 		if err != nil {
 			fmt.Printf("Failed to archive output directory: %v\n", err)
 			os.Remove(tempTarGzPath)
@@ -190,8 +190,8 @@ func runDoBuilds(cmd *cobra.Command, args []string) {
 	}
 }
 
-// zipDirectory archives the contents of a directory into a tar.gz file
-func zipDirectory(sourceDir, tarGzPath string) error {
+// createTarGz archives the contents of a directory into a tar.gz file
+func createTarGz(sourceDir, tarGzPath string) error {
 	// Create the tar.gz file
 	tarGzFile, err := os.Create(tarGzPath)
 	if err != nil {

--- a/cmd/doBuilds_test.go
+++ b/cmd/doBuilds_test.go
@@ -46,9 +46,9 @@ func TestDoBuildsCommandFlags(t *testing.T) {
 	}
 }
 
-func TestZipDirectory(t *testing.T) {
+func TestCreateTarGz(t *testing.T) {
 	// Create a temporary directory for testing
-	tempDir, err := os.MkdirTemp("", "slarty-zip-test")
+	tempDir, err := os.MkdirTemp("", "slarty-targz-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -92,9 +92,9 @@ func TestZipDirectory(t *testing.T) {
 
 	// Create a tar.gz file
 	tarGzPath := filepath.Join(tempDir, "test.tar.gz")
-	err = zipDirectory(sourceDir, tarGzPath)
+	err = createTarGz(sourceDir, tarGzPath)
 	if err != nil {
-		t.Fatalf("zipDirectory failed: %v", err)
+		t.Fatalf("createTarGz failed: %v", err)
 	}
 
 	// Verify the tar.gz file was created
@@ -109,8 +109,8 @@ func TestZipDirectory(t *testing.T) {
 		t.Fatalf("Failed to create extract directory: %v", err)
 	}
 
-	// Use the unzipFile function from doDeploys.go to extract the tar.gz file
-	err = unzipFile(tarGzPath, extractDir)
+	// Use the extractTarGz function from doDeploys.go to extract the tar.gz file
+	err = extractTarGz(tarGzPath, extractDir)
 	if err != nil {
 		t.Fatalf("Failed to extract tar.gz file: %v", err)
 	}

--- a/cmd/doDeploys.go
+++ b/cmd/doDeploys.go
@@ -125,7 +125,7 @@ func runDoDeploys(cmd *cobra.Command, args []string) {
 		}
 
 		// Extract the artifact to the deploy location
-		err = unzipFile(tempFilePath, deployPath)
+		err = extractTarGz(tempFilePath, deployPath)
 		if err != nil {
 			os.Remove(tempFilePath)
 			log.Fatalf("Failed to extract artifact: %v", err)
@@ -138,8 +138,8 @@ func runDoDeploys(cmd *cobra.Command, args []string) {
 	}
 }
 
-// unzipFile extracts the contents of a tar.gz file to a destination directory
-func unzipFile(tarGzPath, destDir string) error {
+// extractTarGz extracts the contents of a tar.gz file to a destination directory
+func extractTarGz(tarGzPath, destDir string) error {
 	// Open the tar.gz file
 	file, err := os.Open(tarGzPath)
 	if err != nil {

--- a/cmd/doDeploys_test.go
+++ b/cmd/doDeploys_test.go
@@ -43,9 +43,9 @@ func TestDoDeploysCommandFlags(t *testing.T) {
 	}
 }
 
-func TestUnzipFile(t *testing.T) {
+func TestExtractTarGz(t *testing.T) {
 	// Create a temporary directory for testing
-	tempDir, err := os.MkdirTemp("", "slarty-unzip-test")
+	tempDir, err := os.MkdirTemp("", "slarty-targz-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -89,9 +89,9 @@ func TestUnzipFile(t *testing.T) {
 
 	// Create a tar.gz file
 	tarGzPath := filepath.Join(tempDir, "test.tar.gz")
-	err = zipDirectory(sourceDir, tarGzPath)
+	err = createTarGz(sourceDir, tarGzPath)
 	if err != nil {
-		t.Fatalf("zipDirectory failed: %v", err)
+		t.Fatalf("createTarGz failed: %v", err)
 	}
 
 	// Extract the tar.gz file
@@ -101,9 +101,9 @@ func TestUnzipFile(t *testing.T) {
 		t.Fatalf("Failed to create extract directory: %v", err)
 	}
 
-	err = unzipFile(tarGzPath, extractDir)
+	err = extractTarGz(tarGzPath, extractDir)
 	if err != nil {
-		t.Fatalf("unzipFile failed: %v", err)
+		t.Fatalf("extractTarGz failed: %v", err)
 	}
 
 	// Verify the extracted files
@@ -134,7 +134,7 @@ func TestUnzipFile(t *testing.T) {
 	}
 }
 
-func TestUnzipFileRejectsPathTraversal(t *testing.T) {
+func TestExtractTarGzRejectsPathTraversal(t *testing.T) {
 	// A malicious archive whose entry name escapes the destination directory
 	// (Zip Slip) must be rejected rather than written outside destDir.
 	tempDir, err := os.MkdirTemp("", "slarty-zipslip-test")
@@ -174,9 +174,9 @@ func TestUnzipFileRejectsPathTraversal(t *testing.T) {
 		t.Fatalf("Failed to create dest directory: %v", err)
 	}
 
-	err = unzipFile(tarGzPath, destDir)
+	err = extractTarGz(tarGzPath, destDir)
 	if err == nil {
-		t.Fatal("expected unzipFile to reject path-traversal entry, got nil error")
+		t.Fatal("expected extractTarGz to reject path-traversal entry, got nil error")
 	}
 	if !strings.Contains(err.Error(), "illegal path in archive") {
 		t.Errorf("expected illegal-path error, got: %v", err)
@@ -191,9 +191,9 @@ func TestUnzipFileRejectsPathTraversal(t *testing.T) {
 
 func TestExtractFile(t *testing.T) {
 	// This is a more focused test of the extractFile function
-	// Since extractFile is not exported, we test it indirectly through unzipFile
-	// The TestUnzipFile test above already covers this functionality
-	t.Skip("extractFile is tested indirectly through unzipFile")
+	// Since extractFile is not exported, we test it indirectly through extractTarGz
+	// The TestExtractTarGz test above already covers this functionality
+	t.Skip("extractFile is tested indirectly through extractTarGz")
 }
 
 func TestRunDoDeploys(t *testing.T) {
@@ -291,11 +291,11 @@ func TestRunDoDeploys(t *testing.T) {
 	artifact1Path := filepath.Join(repoDir, artifact1Name)
 	artifact2Path := filepath.Join(repoDir, artifact2Name)
 
-	err = zipDirectory(sourceDir1, artifact1Path)
+	err = createTarGz(sourceDir1, artifact1Path)
 	if err != nil {
 		t.Fatalf("Failed to create artifact1: %v", err)
 	}
-	err = zipDirectory(sourceDir2, artifact2Path)
+	err = createTarGz(sourceDir2, artifact2Path)
 	if err != nil {
 		t.Fatalf("Failed to create artifact2: %v", err)
 	}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,18 +13,18 @@ The following commands are described in the README but not yet implemented:
 2. **do-builds** - Command to build artifacts that don't exist in the repository
    - Implement the command in `cmd/doBuilds.go`
    - Add functionality to execute build commands
-   - Add functionality to zip output directories
+   - Add functionality to create tar.gz archives of output directories
    - Add functionality to store artifacts in the repository
 
 3. **do-deploys** - Command to deploy artifacts from the repository
    - Implement the command in `cmd/doDeploys.go`
    - Add functionality to download artifacts from the repository
-   - Add functionality to unzip artifacts to deploy locations
+   - Add functionality to extract artifacts to deploy locations
 
 4. **deploy-assets** - Command to deploy assets from the repository
    - Implement the command in `cmd/deployAssets.go`
    - Add functionality to download assets from the repository
-   - Add functionality to unzip assets to deploy locations
+   - Add functionality to extract assets to deploy locations
 
 ## Repository Adapters
 
@@ -42,16 +42,13 @@ The following repository adapters need to be implemented:
 
 ## Other Tasks
 
-1. **Fix Artifact Extension Inconsistency**
-   - The README mentions that artifacts are zip files, but `GetArtifactName` in `slarty/githash.go` returns filenames with a .tar.gz extension
-
-2. **Add Tests**
+1. **Add Tests**
    - Add unit tests for all functionality
    - Add integration tests for commands
 
-3. **Documentation**
+2. **Documentation**
    - Add godoc comments to all exported functions and types
    - Create examples for common use cases
 
-4. **CI/CD**
+3. **CI/CD**
    - Set up GitHub Actions or other CI/CD system for automated testing and building


### PR DESCRIPTION
## Summary

Artifacts have been `tar.gz` since the move away from zip (commit b1f0cd6), but several places still used "zip" terminology, misleading readers about the archive format:

- The README said builds were created by "zipping" the output directory.
- The archival/extraction helpers were named `zipDirectory` / `unzipFile`.
- `docs/todo.md` still listed the now-resolved "Artifact Extension Inconsistency" item and used zip/unzip wording.

## Changes

- Rename helpers: `zipDirectory` → `createTarGz`, `unzipFile` → `extractTarGz` (and matching test names), across `cmd/doBuilds.go`, `cmd/doDeploys.go`, `cmd/deployAssets.go`, and the test files.
- README: describe the archive as "a tar.gz of the output_directory".
- `docs/todo.md`: drop the resolved extension-inconsistency item, renumber, and align remaining wording to tar.gz.

The remaining "Zip Slip" references name the vulnerability class (not the archive format), so they intentionally stay.

## Testing

- `gofmt` clean, `go build ./...`, `go vet ./...` clean
- `go test ./...` passes (helper renames covered by existing tests)

Closes #17