### PR TITLE
Surface git stderr in hash errors

### DIFF
--- a/slarty/githash.go
+++ b/slarty/githash.go
@@ -33,26 +33,30 @@ func HashDirectories(root string, directories []string) (string, error) {
 	}
 
 	var out bytes.Buffer
+	var stderr bytes.Buffer
 	cmd := exec.Command("git")
 	cmd.Dir = rootDir
 	args := []string{"git", "ls-files", "-s"}
 	args = append(args, directories...)
 	cmd.Args = args
 	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 	err = cmd.Run()
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("git ls-files failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
 	var hashout bytes.Buffer
+	var hashStderr bytes.Buffer
 	// out now has all the stuff to pass to the next command and get the hash
 	hashObject := exec.Command("git", "hash-object", "--stdin")
 	hashObject.Stdout = &hashout
+	hashObject.Stderr = &hashStderr
 	hashObject.Stdin = &out
 	err = hashObject.Run()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("git hash-object failed: %w: %s", err, strings.TrimSpace(hashStderr.String()))
 	}
 
 	return strings.Trim(hashout.String(), "\n"), nil

--- a/slarty/githash_test.go
+++ b/slarty/githash_test.go
@@ -101,6 +101,33 @@ func TestGetArtifactName(t *testing.T) {
 	}
 }
 
+// TestHashDirectoriesSurfacesGitStderr verifies that when a git command
+// fails (e.g. the directory is not a git repository), the captured stderr
+// is surfaced in the returned error rather than swallowed.
+func TestHashDirectoriesSurfacesGitStderr(t *testing.T) {
+	// Skip this test if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available, skipping test")
+	}
+
+	// Create a temporary directory that is NOT a git repository.
+	tempDir, err := os.MkdirTemp("", "slarty-stderr-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	_, err = HashDirectories(tempDir, []string{"."})
+	if err == nil {
+		t.Fatalf("HashDirectories did not fail for a non-git directory")
+	}
+
+	// The git stderr text should be surfaced in the error message.
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("Expected error to contain git stderr 'not a git repository', got: %v", err)
+	}
+}
+
 // TestHashDirectories tests the HashDirectories function
 // Note: This test requires git to be installed and a git repository to be present
 func TestHashDirectories(t *testing.T) {


### PR DESCRIPTION
## Summary

`HashDirectories` in `slarty/githash.go` ran two git commands (`git ls-files -s ...` and `git hash-object --stdin`) without capturing their stderr. When git failed (not a git repository, bad pathspec, etc.) the returned error was a bare `exit status 128` with no explanation, making problems hard to diagnose.

## Changes

- Attach a `bytes.Buffer` to `cmd.Stderr` for both git commands.
- Wrap each `cmd.Run()` error to include the trimmed captured stderr (`git ls-files failed: ...` and `git hash-object failed: ...`), preserving the original error via `%w`.
- Add a regression test (`TestHashDirectoriesSurfacesGitStderr`) that runs `HashDirectories` against a non-git temp directory and asserts the returned error is non-nil and contains the git stderr text ("not a git repository").

Behavior is otherwise unchanged.

## Testing

- `gofmt -l slarty/` (no output)
- `go build ./...`
- `go vet ./...`
- `go test ./...`

All pass.

Closes #15