### PR TITLE
Refuse do-cleanup that resolves to the project root

### DIFF
--- a/cmd/doCleanup.go
+++ b/cmd/doCleanup.go
@@ -123,8 +123,35 @@ func runDoCleanup(cmd *cobra.Command, args []string) {
 		// Get the full path to the deploy location
 		deployPath := filepath.Join(artifactConfig.RootDirectory, asset.DeployLocation)
 
+		// Guard against cleaning the project root itself. An empty or "."
+		// deploy_location causes filepath.Join to collapse to RootDirectory,
+		// which would otherwise wipe the entire project. Refuse to clean when
+		// the resolved deploy path is the project root or an ancestor of it.
+		deployAbs, err := filepath.Abs(deployPath)
+		if err != nil {
+			log.Fatalf("Failed to resolve deploy directory: %v", err)
+		}
+		deployAbs = filepath.Clean(deployAbs)
+
+		rootAbs, err := filepath.Abs(artifactConfig.RootDirectory)
+		if err != nil {
+			log.Fatalf("Failed to resolve root directory: %v", err)
+		}
+		rootAbs = filepath.Clean(rootAbs)
+
+		if deployAbs == rootAbs {
+			fmt.Printf(" - Refusing to clean %s: resolves to or contains the project root\n", deployPath)
+			continue
+		}
+		if rel, relErr := filepath.Rel(deployAbs, rootAbs); relErr == nil &&
+			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel) {
+			// rootAbs is inside deployAbs, so deployPath is an ancestor of the root.
+			fmt.Printf(" - Refusing to clean %s: resolves to or contains the project root\n", deployPath)
+			continue
+		}
+
 		// Check if the directory exists
-		_, err := os.Stat(deployPath)
+		_, err = os.Stat(deployPath)
 		if os.IsNotExist(err) {
 			fmt.Printf(" - Directory does not exist: %s\n", deployPath)
 			continue

--- a/cmd/doCleanup_test.go
+++ b/cmd/doCleanup_test.go
@@ -392,3 +392,92 @@ func TestRunDoCleanup(t *testing.T) {
 		}
 	})
 }
+
+func TestRunDoCleanupRefusesProjectRoot(t *testing.T) {
+	// Create a temporary directory to act as the project root.
+	tempDir, err := os.MkdirTemp("", "slarty-do-cleanup-root-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Place a sentinel file in the root that must survive cleanup.
+	sentinel := filepath.Join(tempDir, "sentinel.txt")
+	err = os.WriteFile(sentinel, []byte("do not delete me"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create sentinel file: %v", err)
+	}
+
+	// Create a test artifacts.json with an asset whose deploy_location is empty,
+	// which collapses to the project root via filepath.Join.
+	jsonContent := `{
+		"application": "Test App",
+		"root_directory": "` + tempDir + `",
+		"repository": {
+			"adapter": "Local",
+			"options": {
+				"root": "` + tempDir + `/repo"
+			}
+		},
+		"assets": [
+			{
+				"name": "rootasset",
+				"filename": "root.tar.gz",
+				"deploy_location": ""
+			}
+		]
+	}`
+
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	err = os.WriteFile(configPath, []byte(jsonContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+	}
+
+	// Save and restore globals around the run.
+	oldArtifactsJson := artifactsJson
+	defer func() { artifactsJson = oldArtifactsJson }()
+	artifactsJson = configPath
+
+	oldFilter := filter
+	defer func() { filter = oldFilter }()
+	filter = ""
+
+	oldExclude := exclude
+	defer func() { exclude = oldExclude }()
+	exclude = ""
+
+	// Capture stdout.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	runDoCleanup(cmd, []string{})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// The sentinel file in the project root must still exist.
+	if _, err := os.Stat(sentinel); os.IsNotExist(err) {
+		t.Errorf("Sentinel file %s was deleted; do-cleanup wiped the project root", sentinel)
+	}
+
+	// The artifacts.json must also survive (further proof the root wasn't wiped).
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Errorf("Config file %s was deleted; do-cleanup wiped the project root", configPath)
+	}
+
+	// Output should indicate the asset was refused/skipped.
+	if !strings.Contains(output, "Refusing to clean") {
+		t.Errorf("Expected output to indicate the asset was refused, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary

`do-cleanup` could wipe the entire project root. When an asset's `deploy_location` was empty or `.`, `filepath.Join(RootDirectory, "")` collapsed to `RootDirectory`, and `removeContents` then deleted everything in the project root with no guard.

## Changes

- `cmd/doCleanup.go`: Before calling `removeContents`, resolve both the deploy path and `RootDirectory` to cleaned absolute paths (`filepath.Abs` + `filepath.Clean`). If the resolved deploy path equals the project root, or is an ancestor of it (the root lives inside the deploy path), the asset is skipped with a clear warning (` - Refusing to clean %s: resolves to or contains the project root`) and processing continues to the next asset rather than aborting. This naturally also covers empty and `.` deploy_location values. The existing "directory does not exist" handling is unchanged.
- `cmd/doCleanup_test.go`: Added `TestRunDoCleanupRefusesProjectRoot`, which sets up a temp dir as `RootDirectory` with an asset whose `deploy_location` is empty and a sentinel file in the root, runs `runDoCleanup`, and asserts the sentinel (and config) survive and the output indicates the asset was refused.

## Testing

- `gofmt -l cmd/` (clean)
- `go build ./...`
- `go vet ./...`
- `go test ./...` (all pass)

Closes #14