### PR TITLE
Harden archive extraction and S3 operations

### DIFF
--- a/cmd/doDeploys.go
+++ b/cmd/doDeploys.go
@@ -34,6 +34,19 @@ import (
 	"strings"
 )
 
+// maxDecompressedFileBytes caps the number of bytes extracted for any single
+// archive entry. It guards against decompression bombs that could otherwise
+// fill the disk. The limit is intentionally generous (5 GiB) so legitimate
+// large artifacts are unaffected; tune this constant if larger entries are
+// expected.
+const maxDecompressedFileBytes = 5 << 30 // 5 GiB
+
+// maxDecompressedFileBytesForTest holds the effective per-entry cap. It is
+// seeded from maxDecompressedFileBytes and exists as a variable only so tests
+// can lower the limit without writing gigabytes of data. Production code never
+// reassigns it.
+var maxDecompressedFileBytesForTest int64 = maxDecompressedFileBytes
+
 // doDeploysCmd represents the doDeploys command
 var doDeploysCmd = &cobra.Command{
 	Use:   "do-deploys",
@@ -209,17 +222,25 @@ func extractTarFile(header *tar.Header, tarReader *tar.Reader, destDir string) e
 			return fmt.Errorf("failed to create directory for file: %w", err)
 		}
 
-		// Create the destination file
-		destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
+		// Create the destination file. Mask the header mode to 0o777 so a
+		// malicious archive cannot set setuid/setgid/sticky or other special
+		// bits (those live above 0o777) on extracted files.
+		destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode&0o777))
 		if err != nil {
 			return fmt.Errorf("failed to create destination file: %w", err)
 		}
 		defer destFile.Close()
 
-		// Copy the file contents
-		_, err = io.Copy(destFile, tarReader)
-		if err != nil {
+		// Copy the file contents, bounding the amount written per entry to
+		// guard against decompression bombs. io.CopyN with a limit one byte
+		// over the cap lets us detect an entry that exceeds the cap.
+		limit := maxDecompressedFileBytesForTest
+		written, err := io.CopyN(destFile, tarReader, limit+1)
+		if err != nil && err != io.EOF {
 			return fmt.Errorf("failed to copy file contents: %w", err)
+		}
+		if written > limit {
+			return fmt.Errorf("file %s in archive exceeds max size", header.Name)
 		}
 	default:
 		// Skip other types of files (symlinks, etc.)

--- a/cmd/doDeploys_test.go
+++ b/cmd/doDeploys_test.go
@@ -189,6 +189,116 @@ func TestExtractTarGzRejectsPathTraversal(t *testing.T) {
 	}
 }
 
+func TestExtractTarGzMasksSpecialModeBits(t *testing.T) {
+	// A malicious archive must not be able to set setuid/setgid/sticky bits on
+	// extracted files; extraction must mask the header mode down to 0o777.
+	tempDir, err := os.MkdirTemp("", "slarty-mode-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tarGzPath := filepath.Join(tempDir, "setuid.tar.gz")
+	f, err := os.Create(tarGzPath)
+	if err != nil {
+		t.Fatalf("Failed to create tar.gz: %v", err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	payload := []byte("payload")
+	// Mode includes the setuid bit (0o4000) plus rwxr-xr-x.
+	hdr := &tar.Header{
+		Name:     "evil",
+		Mode:     0o4755,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("Failed to write tar header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("Failed to write tar payload: %v", err)
+	}
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	destDir := filepath.Join(tempDir, "dest")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("Failed to create dest directory: %v", err)
+	}
+
+	if err := extractTarGz(tarGzPath, destDir); err != nil {
+		t.Fatalf("extractTarGz failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(destDir, "evil"))
+	if err != nil {
+		t.Fatalf("Failed to stat extracted file: %v", err)
+	}
+	// The mode (including special bits, after umask) must not retain setuid.
+	if info.Mode()&os.ModeSetuid != 0 {
+		t.Errorf("extracted file retained setuid bit: mode %v", info.Mode())
+	}
+	if perm := info.Mode().Perm(); perm&^0o777 != 0 {
+		t.Errorf("extracted file has bits above 0o777: mode %v", info.Mode())
+	}
+}
+
+func TestExtractTarGzRejectsOversizedEntry(t *testing.T) {
+	// An entry that streams more than maxDecompressedFileBytes must be
+	// rejected. To keep the test fast we reduce the limit temporarily rather
+	// than writing gigabytes; the data written stays just over the lowered cap.
+	tempDir, err := os.MkdirTemp("", "slarty-bomb-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tarGzPath := filepath.Join(tempDir, "bomb.tar.gz")
+	f, err := os.Create(tarGzPath)
+	if err != nil {
+		t.Fatalf("Failed to create tar.gz: %v", err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	// Write more bytes than the (lowered) limit we set below.
+	payload := bytes.Repeat([]byte("A"), 2048)
+	hdr := &tar.Header{
+		Name:     "big.bin",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("Failed to write tar header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("Failed to write tar payload: %v", err)
+	}
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	// Temporarily lower the cap so we exceed it with a tiny payload.
+	old := maxDecompressedFileBytesForTest
+	maxDecompressedFileBytesForTest = 1024
+	defer func() { maxDecompressedFileBytesForTest = old }()
+
+	destDir := filepath.Join(tempDir, "dest")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("Failed to create dest directory: %v", err)
+	}
+
+	err = extractTarGz(tarGzPath, destDir)
+	if err == nil {
+		t.Fatal("expected extractTarGz to reject oversized entry, got nil error")
+	}
+	if !strings.Contains(err.Error(), "exceeds max size") {
+		t.Errorf("expected exceeds-max-size error, got: %v", err)
+	}
+}
+
 func TestExtractFile(t *testing.T) {
 	// This is a more focused test of the extractFile function
 	// Since extractFile is not exported, we test it indirectly through extractTarGz

--- a/slarty/githash.go
+++ b/slarty/githash.go
@@ -34,11 +34,9 @@ func HashDirectories(root string, directories []string) (string, error) {
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := exec.Command("git")
+	args := append([]string{"ls-files", "-s"}, directories...)
+	cmd := exec.Command("git", args...)
 	cmd.Dir = rootDir
-	args := []string{"git", "ls-files", "-s"}
-	args = append(args, directories...)
-	cmd.Args = args
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/slarty/repository.go
+++ b/slarty/repository.go
@@ -9,11 +9,17 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
+
+// s3OperationTimeout bounds how long any single S3 operation may run. It is
+// intentionally generous to accommodate large artifact transfers while still
+// preventing an operation from hanging indefinitely.
+const s3OperationTimeout = 30 * time.Minute
 
 // RepositoryAdapter defines the interface for repository adapters
 type RepositoryAdapter interface {
@@ -221,8 +227,9 @@ func (s *S3RepositoryAdapter) StoreArtifact(artifactPath, artifactName string) e
 	}
 	defer file.Close()
 
-	// Create a context
-	ctx := context.Background()
+	// Create a context with a generous timeout
+	ctx, cancel := context.WithTimeout(context.Background(), s3OperationTimeout)
+	defer cancel()
 
 	// Upload the file to S3
 	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
@@ -239,8 +246,9 @@ func (s *S3RepositoryAdapter) StoreArtifact(artifactPath, artifactName string) e
 
 // ArtifactExists checks if an artifact exists in the S3 repository
 func (s *S3RepositoryAdapter) ArtifactExists(artifactName string) (bool, error) {
-	// Create a context
-	ctx := context.Background()
+	// Create a context with a generous timeout
+	ctx, cancel := context.WithTimeout(context.Background(), s3OperationTimeout)
+	defer cancel()
 
 	// Check if the object exists in S3
 	_, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
@@ -261,8 +269,9 @@ func (s *S3RepositoryAdapter) ArtifactExists(artifactName string) (bool, error) 
 
 // RetrieveArtifact retrieves an artifact from the S3 repository
 func (s *S3RepositoryAdapter) RetrieveArtifact(artifactName, destinationPath string) error {
-	// Create a context
-	ctx := context.Background()
+	// Create a context with a generous timeout
+	ctx, cancel := context.WithTimeout(context.Background(), s3OperationTimeout)
+	defer cancel()
 
 	// Get the object from S3
 	result, err := s.client.GetObject(ctx, &s3.GetObjectInput{


### PR DESCRIPTION
## Summary

Four small robustness-hardening fixes (issue #16) that reduce the blast
radius of malicious archives and hung network calls, with no change to
normal behavior.

## Changes

- **Mask extracted file modes** (`cmd/doDeploys.go`): regular files are now
  created with `os.FileMode(header.Mode & 0o777)`, stripping
  setuid/setgid/sticky bits a malicious tarball could otherwise set.
- **Bound per-entry decompression** (`cmd/doDeploys.go`): replaced the
  unbounded `io.Copy` with a capped `io.CopyN` against a new
  `maxDecompressedFileBytes = 5 << 30` (5 GiB) constant. An entry exceeding
  the cap returns `file %s in archive exceeds max size`. The cap is a const
  (surfaced through a package var only so tests can lower it) and can be
  tuned if larger artifacts are expected.
- **S3 timeouts** (`slarty/repository.go`): `StoreArtifact`, `ArtifactExists`,
  and `RetrieveArtifact` now use `context.WithTimeout` with a new
  package-level `s3OperationTimeout = 30 * time.Minute` (generous, to
  accommodate large transfers) and `defer cancel()`.
- **Idiomatic git invocation** (`slarty/githash.go`): rebuilt the first git
  command as `exec.Command("git", append([]string{"ls-files", "-s"}, directories...)...)`
  instead of mutating `cmd.Args`. Existing stderr capture and error wrapping
  preserved; `cmd.Dir` unchanged.

## Testing

- Added `TestExtractTarGzMasksSpecialModeBits` (setuid entry extracted
  without the special bit) and `TestExtractTarGzRejectsOversizedEntry`
  (over-cap entry rejected; cap lowered in-test so no GiB are written).
- `gofmt -l cmd/ slarty/` clean, `go build ./...`, `go vet ./...`,
  `go test ./...` all pass.

Closes #16