### PR TITLE
Add validate command for artifacts.json

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,197 @@
+/*
+Copyright © 2025 David Stockton <dave@davidstockton.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dstockto/slarty/slarty"
+	"github.com/spf13/cobra"
+)
+
+// validateCmd represents the validate command
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate artifacts.json and report common problems",
+	Long: `Validates the artifacts.json configuration and reports common problems such as
+duplicate names, missing directories, and empty deploy locations (which can wipe the
+project root). All problems are reported, and the command exits non-zero if any errors
+are found.`,
+	Run: runValidate,
+}
+
+func runValidate(cmd *cobra.Command, args []string) {
+	artifactConfig, err := slarty.ReadArtifactsJson(artifactsJson)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: unable to read %s: %v\n", artifactsJson, err)
+		os.Exit(1)
+	}
+
+	errCount, _ := validateConfig(os.Stdout, artifactConfig)
+
+	if errCount > 0 {
+		os.Exit(1)
+	}
+}
+
+// validateConfig inspects the configuration, writes any problems and a summary to w,
+// and returns the number of errors and warnings found. It never calls os.Exit so it
+// can be exercised by tests.
+func validateConfig(w io.Writer, config *slarty.ArtifactsConfig) (errCount, warnCount int) {
+	var errs []string
+	var warns []string
+
+	addError := func(format string, a ...interface{}) {
+		errs = append(errs, fmt.Sprintf(format, a...))
+	}
+	addWarning := func(format string, a ...interface{}) {
+		warns = append(warns, fmt.Sprintf(format, a...))
+	}
+
+	// No artifacts and no assets is a warning.
+	if len(config.Artifacts) == 0 && len(config.Assets) == 0 {
+		addWarning("no artifacts and no assets are defined")
+	}
+
+	// Validate artifacts.
+	seenArtifactNames := make(map[string]bool)
+	for i, artifact := range config.Artifacts {
+		label := artifact.Name
+		if strings.TrimSpace(label) == "" {
+			label = fmt.Sprintf("artifact #%d", i+1)
+		}
+
+		if strings.TrimSpace(artifact.Name) == "" {
+			addError("%s has an empty name", label)
+		} else {
+			lower := strings.ToLower(artifact.Name)
+			if seenArtifactNames[lower] {
+				addError("duplicate artifact name %q (names are case-insensitive)", artifact.Name)
+			}
+			seenArtifactNames[lower] = true
+		}
+
+		if strings.TrimSpace(artifact.DeployLocation) == "" {
+			addError("%s has an empty deploy_location (this can wipe the project root)", label)
+		} else if artifact.DeployLocation == "." {
+			addWarning("%s has deploy_location \".\" which resolves to the project root", label)
+		}
+
+		if len(artifact.Directories) == 0 {
+			addError("%s has no directories defined", label)
+		} else {
+			for _, dir := range artifact.Directories {
+				if strings.TrimSpace(dir) == "" {
+					addError("%s has an empty directory entry", label)
+					continue
+				}
+				path := filepath.Join(config.RootDirectory, dir)
+				if _, err := os.Stat(path); os.IsNotExist(err) {
+					addError("%s references directory %q which does not exist (%s)", label, dir, path)
+				}
+			}
+		}
+
+		if strings.TrimSpace(artifact.Command) == "" {
+			addError("%s has an empty command", label)
+		}
+		if strings.TrimSpace(artifact.OutputDirectory) == "" {
+			addError("%s has an empty output_directory", label)
+		}
+		if strings.TrimSpace(artifact.ArtifactPrefix) == "" {
+			addError("%s has an empty artifact_prefix", label)
+		}
+	}
+
+	// Validate assets.
+	seenAssetNames := make(map[string]bool)
+	for i, asset := range config.Assets {
+		label := asset.Name
+		if strings.TrimSpace(label) == "" {
+			label = fmt.Sprintf("asset #%d", i+1)
+		}
+
+		if strings.TrimSpace(asset.Name) == "" {
+			addError("%s has an empty name", label)
+		} else {
+			lower := strings.ToLower(asset.Name)
+			if seenAssetNames[lower] {
+				addError("duplicate asset name %q (names are case-insensitive)", asset.Name)
+			}
+			seenAssetNames[lower] = true
+		}
+
+		if strings.TrimSpace(asset.Filename) == "" {
+			addError("%s has an empty filename", label)
+		}
+
+		if strings.TrimSpace(asset.DeployLocation) == "" {
+			addError("%s has an empty deploy_location (this can wipe the project root)", label)
+		} else if asset.DeployLocation == "." {
+			addWarning("%s has deploy_location \".\" which resolves to the project root", label)
+		}
+	}
+
+	// Validate repository adapter.
+	adapter := strings.ToLower(strings.TrimSpace(config.Repository.Adapter))
+	switch adapter {
+	case "local":
+		if strings.TrimSpace(config.Repository.Options.Root) == "" {
+			addError("repository adapter \"local\" requires a non-empty root")
+		}
+	case "s3":
+		if strings.TrimSpace(config.Repository.Options.Region) == "" {
+			addError("repository adapter \"s3\" requires a non-empty region")
+		}
+		if strings.TrimSpace(config.Repository.Options.BucketName) == "" {
+			addError("repository adapter \"s3\" requires a non-empty bucket-name")
+		}
+	default:
+		addError("unknown repository adapter %q (expected \"local\" or \"s3\")", config.Repository.Adapter)
+	}
+
+	for _, e := range errs {
+		fmt.Fprintf(w, "ERROR: %s\n", e)
+	}
+	for _, wn := range warns {
+		fmt.Fprintf(w, "WARNING: %s\n", wn)
+	}
+
+	errCount = len(errs)
+	warnCount = len(warns)
+
+	if errCount == 0 && warnCount == 0 {
+		fmt.Fprintln(w, "artifacts.json is valid")
+	} else {
+		fmt.Fprintf(w, "Found %d error(s) and %d warning(s)\n", errCount, warnCount)
+	}
+
+	return errCount, warnCount
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dstockto/slarty/slarty"
+)
+
+func TestValidateCommand(t *testing.T) {
+	if validateCmd.Use != "validate" {
+		t.Errorf("Expected validate command Use to be 'validate', got '%s'", validateCmd.Use)
+	}
+	if validateCmd.Short == "" {
+		t.Error("validate command Short description should not be empty")
+	}
+	if validateCmd.Long == "" {
+		t.Error("validate command Long description should not be empty")
+	}
+	if validateCmd.Run == nil {
+		t.Error("validate command Run function should not be nil")
+	}
+}
+
+// writeConfig writes the given JSON to an artifacts.json inside a fresh temp
+// directory and returns the parsed config (so RootDirectory resolves to tempDir).
+func writeConfig(t *testing.T, jsonContent string) *slarty.ArtifactsConfig {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "slarty-validate-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	if err := os.WriteFile(configPath, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	config, err := slarty.ReadArtifactsJson(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read artifacts.json: %v", err)
+	}
+
+	// Create any referenced directories so the "directory missing" check is
+	// controlled per-test rather than by accident. Directories whose name
+	// contains "does-not-exist" are intentionally left missing.
+	for _, artifact := range config.Artifacts {
+		for _, dir := range artifact.Directories {
+			if strings.TrimSpace(dir) == "" || strings.Contains(dir, "does-not-exist") {
+				continue
+			}
+			_ = os.MkdirAll(filepath.Join(tempDir, dir), 0755)
+		}
+	}
+
+	return config
+}
+
+func TestValidateConfigValid(t *testing.T) {
+	config := writeConfig(t, `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": {
+			"adapter": "local",
+			"options": { "root": "/tmp/repo" }
+		},
+		"artifacts": [
+			{
+				"name": "alpha",
+				"directories": ["dir1"],
+				"command": "make alpha",
+				"output_directory": "build/alpha",
+				"deploy_location": "deploy/alpha",
+				"artifact_prefix": "alpha"
+			}
+		],
+		"assets": [
+			{ "name": "config", "filename": "app.conf", "deploy_location": "etc" }
+		]
+	}`)
+
+	var buf bytes.Buffer
+	errCount, warnCount := validateConfig(&buf, config)
+
+	if errCount != 0 {
+		t.Errorf("Expected 0 errors, got %d. Output:\n%s", errCount, buf.String())
+	}
+	if warnCount != 0 {
+		t.Errorf("Expected 0 warnings, got %d. Output:\n%s", warnCount, buf.String())
+	}
+	if !strings.Contains(buf.String(), "artifacts.json is valid") {
+		t.Errorf("Expected success message, got:\n%s", buf.String())
+	}
+}
+
+func TestValidateConfigSeededProblems(t *testing.T) {
+	// Two artifacts named "dupe" (case-insensitive), one with an empty
+	// deploy_location and a missing directory; an unknown repository adapter.
+	config := writeConfig(t, `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": {
+			"adapter": "ftp",
+			"options": {}
+		},
+		"artifacts": [
+			{
+				"name": "Dupe",
+				"directories": ["does-not-exist"],
+				"command": "make a",
+				"output_directory": "build/a",
+				"deploy_location": "",
+				"artifact_prefix": "a"
+			},
+			{
+				"name": "dupe",
+				"directories": ["dir2"],
+				"command": "make b",
+				"output_directory": "build/b",
+				"deploy_location": "deploy/b",
+				"artifact_prefix": "b"
+			}
+		]
+	}`)
+
+	var buf bytes.Buffer
+	errCount, warnCount := validateConfig(&buf, config)
+	output := buf.String()
+
+	if errCount == 0 {
+		t.Fatalf("Expected errors, got none. Output:\n%s", output)
+	}
+	_ = warnCount
+
+	checks := map[string]string{
+		"empty deploy_location": "deploy_location",
+		"duplicate name":        "duplicate artifact name",
+		"missing directory":     "does not exist",
+		"unknown adapter":       "unknown repository adapter",
+	}
+	for desc, want := range checks {
+		if !strings.Contains(output, want) {
+			t.Errorf("Expected output to report %s (substring %q). Output:\n%s", desc, want, output)
+		}
+	}
+
+	if !strings.Contains(output, "Found ") {
+		t.Errorf("Expected a summary line, got:\n%s", output)
+	}
+}
+
+func TestValidateConfigWarnings(t *testing.T) {
+	// deploy_location "." is a warning, not an error.
+	config := writeConfig(t, `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": {
+			"adapter": "s3",
+			"options": { "region": "us-east-1", "bucket-name": "my-bucket" }
+		},
+		"artifacts": [
+			{
+				"name": "alpha",
+				"directories": ["dir1"],
+				"command": "make alpha",
+				"output_directory": "build/alpha",
+				"deploy_location": ".",
+				"artifact_prefix": "alpha"
+			}
+		]
+	}`)
+
+	var buf bytes.Buffer
+	errCount, warnCount := validateConfig(&buf, config)
+	output := buf.String()
+
+	if errCount != 0 {
+		t.Errorf("Expected 0 errors, got %d. Output:\n%s", errCount, output)
+	}
+	if warnCount == 0 {
+		t.Errorf("Expected a warning for deploy_location '.', got none. Output:\n%s", output)
+	}
+	if !strings.Contains(output, "WARNING:") {
+		t.Errorf("Expected WARNING prefix, got:\n%s", output)
+	}
+}
+
+func TestValidateConfigEmpty(t *testing.T) {
+	// No artifacts and no assets: warning, but a valid s3 repo so no errors.
+	config := writeConfig(t, `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": {
+			"adapter": "s3",
+			"options": { "region": "us-east-1", "bucket-name": "my-bucket" }
+		}
+	}`)
+
+	var buf bytes.Buffer
+	errCount, warnCount := validateConfig(&buf, config)
+	output := buf.String()
+
+	if errCount != 0 {
+		t.Errorf("Expected 0 errors, got %d. Output:\n%s", errCount, output)
+	}
+	if warnCount == 0 || !strings.Contains(output, "no artifacts and no assets") {
+		t.Errorf("Expected warning about no artifacts/assets, got:\n%s", output)
+	}
+}
+
+func TestValidateConfigS3MissingOptions(t *testing.T) {
+	config := writeConfig(t, `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": {
+			"adapter": "s3",
+			"options": {}
+		},
+		"artifacts": [
+			{
+				"name": "alpha",
+				"directories": ["dir1"],
+				"command": "make alpha",
+				"output_directory": "build/alpha",
+				"deploy_location": "deploy/alpha",
+				"artifact_prefix": "alpha"
+			}
+		]
+	}`)
+
+	var buf bytes.Buffer
+	errCount, _ := validateConfig(&buf, config)
+	output := buf.String()
+
+	if errCount == 0 {
+		t.Fatalf("Expected errors for missing s3 region/bucket, got none. Output:\n%s", output)
+	}
+	if !strings.Contains(output, "region") || !strings.Contains(output, "bucket-name") {
+		t.Errorf("Expected errors about region and bucket-name, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `slarty validate` command that inspects `artifacts.json` and reports common problems, exiting non-zero if any errors are found. This catches footguns early — most notably an empty `deploy_location`, which resolves to the project root and can wipe it during deploy/cleanup.

The validator collects ALL problems before reporting, classifies each as an error or a warning, prints them with `ERROR:` / `WARNING:` prefixes, and finishes with a summary line (`Found N error(s) and M warning(s)` or `artifacts.json is valid`). The validation logic lives in a testable `validateConfig` function that returns counts; only the cobra `Run` wrapper calls `os.Exit`.

## Checks

Errors:
- Duplicate artifact names (case-insensitive) and duplicate asset names
- Empty `deploy_location` on any artifact or asset (called out as dangerous)
- Empty/missing `directories` on an artifact (and empty directory entries)
- A listed directory that does not exist on disk (resolved relative to `RootDirectory` via `filepath.Join`, matching the rest of the code)
- Empty `name`, `command`, `output_directory`, or `artifact_prefix` on an artifact
- Empty `name` or `filename` on an asset
- Unknown repository adapter (anything other than local/s3, case-insensitive)
- Adapter `local` with empty `root`
- Adapter `s3` with empty `region` or empty `bucket-name`

Warnings:
- `deploy_location` equal to `.` (resolves to the project root)
- No artifacts AND no assets defined

## Testing

- `gofmt -l cmd/ slarty/` — clean
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — passes

Tests cover a valid config, a config with several seeded problems (empty deploy_location, case-insensitive duplicate names, unknown adapter, missing directory), the `.` deploy_location warning, the empty-config warning, and missing s3 options.

Closes #25