### PR TITLE
Add --json output to table commands

### DIFF
--- a/cmd/artifactNames.go
+++ b/cmd/artifactNames.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/dstockto/slarty/slarty"
 	"github.com/spf13/cobra"
@@ -74,6 +75,26 @@ func runArtifactNames(cmd *cobra.Command, args []string) {
 		artifactNames[artifact.Name] = filename
 	}
 
+	if jsonOutput {
+		type artifactNameEntry struct {
+			Application  string `json:"application"`
+			ArtifactName string `json:"artifact_name"`
+		}
+		entries := make([]artifactNameEntry, 0, len(artifacts))
+		for _, artifact := range artifacts {
+			entries = append(entries, artifactNameEntry{
+				Application:  artifact.Name,
+				ArtifactName: artifactNames[artifact.Name],
+			})
+		}
+		out, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		fmt.Println(string(out))
+		return
+	}
+
 	if longestName == 0 {
 		fmt.Println("No artifacts found")
 		return
@@ -99,6 +120,7 @@ func init() {
 
 	// Here you will define your flags and configuration settings.
 	artifactNamesCmd.Flags().StringVarP(&filter, "filter", "f", "", "-f \"application1,application2\"")
+	artifactNamesCmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
 	// artifactNamesCmd.PersistentFlags().String("foo", "", "A help for foo")

--- a/cmd/artifactNames_test.go
+++ b/cmd/artifactNames_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -39,6 +40,153 @@ func TestArtifactNamesCommandFlags(t *testing.T) {
 	if flags.Lookup("filter") == nil {
 		t.Error("artifact-names command should have 'filter' flag")
 	}
+
+	// Check json flag
+	if flags.Lookup("json") == nil {
+		t.Error("artifact-names command should have 'json' flag")
+	}
+}
+
+func TestRunArtifactNamesJSON(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "slarty-artifact-names-json-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	order := []string{"zebra", "apple", "mango"}
+
+	var artifactsJSON strings.Builder
+	for i, name := range order {
+		if i > 0 {
+			artifactsJSON.WriteString(",")
+		}
+		artifactsJSON.WriteString(`{
+			"name": "` + name + `",
+			"directories": ["` + name + `"],
+			"command": "make ` + name + `",
+			"output_directory": "build/` + name + `",
+			"deploy_location": "deploy/` + name + `",
+			"artifact_prefix": "` + name + `"
+		}`)
+	}
+
+	jsonContent := `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": { "adapter": "Local", "options": { "root": "/tmp/repo" } },
+		"artifacts": [` + artifactsJSON.String() + `]
+	}`
+
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	if err := os.WriteFile(configPath, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test User")
+	for _, name := range order {
+		dirPath := filepath.Join(tempDir, name)
+		if err := os.Mkdir(dirPath, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dirPath, "test.txt"), []byte(name), 0644); err != nil {
+			t.Fatalf("Failed to create file in %s: %v", name, err)
+		}
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "Initial commit")
+
+	oldArtifactsJson := artifactsJson
+	defer func() { artifactsJson = oldArtifactsJson }()
+	artifactsJson = configPath
+
+	oldFilter := filter
+	defer func() { filter = oldFilter }()
+	filter = ""
+
+	oldJSON := jsonOutput
+	defer func() { jsonOutput = oldJSON }()
+
+	type entry struct {
+		Application  string `json:"application"`
+		ArtifactName string `json:"artifact_name"`
+	}
+
+	t.Run("ValidJSONInConfigOrder", func(t *testing.T) {
+		jsonOutput = true
+		defer func() { jsonOutput = false }()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		runArtifactNames(&cobra.Command{Use: "test"}, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		var entries []entry
+		if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if len(entries) != len(order) {
+			t.Fatalf("Expected %d entries, got %d: %s", len(order), len(entries), buf.String())
+		}
+		for i, name := range order {
+			if entries[i].Application != name {
+				t.Errorf("Entry %d: expected application %q, got %q", i, name, entries[i].Application)
+			}
+			if entries[i].ArtifactName == "" {
+				t.Errorf("Entry %d: expected non-empty artifact_name", i)
+			}
+		}
+	})
+
+	t.Run("EmptyArrayWhenNoArtifacts", func(t *testing.T) {
+		jsonOutput = true
+		oldF := filter
+		filter = "non-existent"
+		defer func() {
+			jsonOutput = false
+			filter = oldF
+		}()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		runArtifactNames(&cobra.Command{Use: "test"}, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		var entries []entry
+		if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput: %s", err, buf.String())
+		}
+		if len(entries) != 0 {
+			t.Errorf("Expected empty array, got %d entries: %s", len(entries), buf.String())
+		}
+		if strings.Contains(buf.String(), "No artifacts found") {
+			t.Errorf("JSON mode should not print 'No artifacts found', got: %s", buf.String())
+		}
+	})
 }
 
 func TestRunArtifactNamesPreservesConfigOrder(t *testing.T) {

--- a/cmd/hashApplication.go
+++ b/cmd/hashApplication.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/dstockto/slarty/slarty"
 	"github.com/spf13/cobra"
@@ -71,6 +72,26 @@ func runHashApplication(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	if jsonOutput {
+		type artifactHashEntry struct {
+			Application string `json:"application"`
+			Hash        string `json:"hash"`
+		}
+		entries := make([]artifactHashEntry, 0, len(artifacts))
+		for _, artifact := range artifacts {
+			entries = append(entries, artifactHashEntry{
+				Application: artifact.Name,
+				Hash:        artifactHashes[artifact.Name],
+			})
+		}
+		out, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		fmt.Println(string(out))
+		return
+	}
+
 	if longestName == 0 {
 		fmt.Println("No artifacts found")
 		return
@@ -101,6 +122,7 @@ func init() {
 	// and all subcommands, e.g.:
 	// hashApplicationCmd.PersistentFlags().String("foo", "", "A help for foo")
 	hashApplicationCmd.Flags().StringVarP(&filter, "filter", "f", "", "-f \"application1,application2\"")
+	hashApplicationCmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// hashApplicationCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/cmd/hashApplication_test.go
+++ b/cmd/hashApplication_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -39,6 +40,153 @@ func TestHashApplicationCommandFlags(t *testing.T) {
 	if flags.Lookup("filter") == nil {
 		t.Error("hash-application command should have 'filter' flag")
 	}
+
+	// Check json flag
+	if flags.Lookup("json") == nil {
+		t.Error("hash-application command should have 'json' flag")
+	}
+}
+
+func TestRunHashApplicationJSON(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "slarty-hash-application-json-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	order := []string{"zebra", "apple", "mango"}
+
+	var artifactsJSON strings.Builder
+	for i, name := range order {
+		if i > 0 {
+			artifactsJSON.WriteString(",")
+		}
+		artifactsJSON.WriteString(`{
+			"name": "` + name + `",
+			"directories": ["` + name + `"],
+			"command": "make ` + name + `",
+			"output_directory": "build/` + name + `",
+			"deploy_location": "deploy/` + name + `",
+			"artifact_prefix": "` + name + `"
+		}`)
+	}
+
+	jsonContent := `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": { "adapter": "Local", "options": { "root": "/tmp/repo" } },
+		"artifacts": [` + artifactsJSON.String() + `]
+	}`
+
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	if err := os.WriteFile(configPath, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test User")
+	for _, name := range order {
+		dirPath := filepath.Join(tempDir, name)
+		if err := os.Mkdir(dirPath, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dirPath, "test.txt"), []byte(name), 0644); err != nil {
+			t.Fatalf("Failed to create file in %s: %v", name, err)
+		}
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "Initial commit")
+
+	oldArtifactsJson := artifactsJson
+	defer func() { artifactsJson = oldArtifactsJson }()
+	artifactsJson = configPath
+
+	oldFilter := filter
+	defer func() { filter = oldFilter }()
+	filter = ""
+
+	oldJSON := jsonOutput
+	defer func() { jsonOutput = oldJSON }()
+
+	type entry struct {
+		Application string `json:"application"`
+		Hash        string `json:"hash"`
+	}
+
+	t.Run("ValidJSONInConfigOrder", func(t *testing.T) {
+		jsonOutput = true
+		defer func() { jsonOutput = false }()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		runHashApplication(&cobra.Command{Use: "test"}, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		var entries []entry
+		if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if len(entries) != len(order) {
+			t.Fatalf("Expected %d entries, got %d: %s", len(order), len(entries), buf.String())
+		}
+		for i, name := range order {
+			if entries[i].Application != name {
+				t.Errorf("Entry %d: expected application %q, got %q", i, name, entries[i].Application)
+			}
+			if entries[i].Hash == "" {
+				t.Errorf("Entry %d: expected non-empty hash", i)
+			}
+		}
+	})
+
+	t.Run("EmptyArrayWhenNoArtifacts", func(t *testing.T) {
+		jsonOutput = true
+		oldF := filter
+		filter = "non-existent"
+		defer func() {
+			jsonOutput = false
+			filter = oldF
+		}()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		runHashApplication(&cobra.Command{Use: "test"}, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		var entries []entry
+		if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput: %s", err, buf.String())
+		}
+		if len(entries) != 0 {
+			t.Errorf("Expected empty array, got %d entries: %s", len(entries), buf.String())
+		}
+		if strings.Contains(buf.String(), "No artifacts found") {
+			t.Errorf("JSON mode should not print 'No artifacts found', got: %s", buf.String())
+		}
+	})
 }
 
 func TestRunHashApplication(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	artifactsJson string
 	filter        string
 	local         bool
+	jsonOutput    bool
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/shouldBuild.go
+++ b/cmd/shouldBuild.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/dstockto/slarty/slarty"
 	"github.com/spf13/cobra"
@@ -91,6 +92,26 @@ func runShouldBuild(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	if jsonOutput {
+		type buildNeededEntry struct {
+			Application string `json:"application"`
+			BuildNeeded bool   `json:"build_needed"`
+		}
+		entries := make([]buildNeededEntry, 0, len(artifacts))
+		for _, artifact := range artifacts {
+			entries = append(entries, buildNeededEntry{
+				Application: artifact.Name,
+				BuildNeeded: buildNeeded[artifact.Name],
+			})
+		}
+		out, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		fmt.Println(string(out))
+		return
+	}
+
 	if len(artifacts) == 0 {
 		fmt.Println("No artifacts found")
 		return
@@ -125,4 +146,5 @@ func init() {
 
 	// Here you will define your flags and configuration settings.
 	shouldBuildCmd.Flags().StringVarP(&filter, "filter", "f", "", "-f \"application1,application2\"")
+	shouldBuildCmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
 }

--- a/cmd/shouldBuild_test.go
+++ b/cmd/shouldBuild_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -40,6 +41,180 @@ func TestShouldBuildCommandFlags(t *testing.T) {
 	if flags.Lookup("filter") == nil {
 		t.Error("should-build command should have 'filter' flag")
 	}
+
+	// Check json flag
+	if flags.Lookup("json") == nil {
+		t.Error("should-build command should have 'json' flag")
+	}
+}
+
+func TestRunShouldBuildJSON(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "slarty-should-build-json-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	repoDir := filepath.Join(tempDir, "repo")
+	if err := os.Mkdir(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create repository directory: %v", err)
+	}
+
+	// zebra exists in the repo (no build needed), apple and mango do not.
+	order := []string{"zebra", "apple", "mango"}
+
+	var artifactsJSON strings.Builder
+	for i, name := range order {
+		if i > 0 {
+			artifactsJSON.WriteString(",")
+		}
+		artifactsJSON.WriteString(`{
+			"name": "` + name + `",
+			"directories": ["` + name + `"],
+			"command": "make ` + name + `",
+			"output_directory": "build/` + name + `",
+			"deploy_location": "deploy/` + name + `",
+			"artifact_prefix": "` + name + `"
+		}`)
+	}
+
+	jsonContent := `{
+		"application": "Test App",
+		"root_directory": "__DIR__",
+		"repository": { "adapter": "Local", "options": { "root": "` + repoDir + `" } },
+		"artifacts": [` + artifactsJSON.String() + `]
+	}`
+
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	if err := os.WriteFile(configPath, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test User")
+	for _, name := range order {
+		dirPath := filepath.Join(tempDir, name)
+		if err := os.Mkdir(dirPath, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dirPath, "test.txt"), []byte(name), 0644); err != nil {
+			t.Fatalf("Failed to create file in %s: %v", name, err)
+		}
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "Initial commit")
+
+	// Make zebra's artifact already exist in the repo.
+	artifactConfig, err := slarty.ReadArtifactsJson(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read artifacts.json: %v", err)
+	}
+	zebraName, err := slarty.GetArtifactName("zebra", artifactConfig)
+	if err != nil {
+		t.Fatalf("Failed to get artifact name for zebra: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, zebraName), []byte("artifact"), 0644); err != nil {
+		t.Fatalf("Failed to create artifact file: %v", err)
+	}
+
+	oldArtifactsJson := artifactsJson
+	defer func() { artifactsJson = oldArtifactsJson }()
+	artifactsJson = configPath
+
+	oldFilter := filter
+	defer func() { filter = oldFilter }()
+	filter = ""
+
+	oldLocal := local
+	defer func() { local = oldLocal }()
+	local = true
+
+	oldJSON := jsonOutput
+	defer func() { jsonOutput = oldJSON }()
+
+	type entry struct {
+		Application string `json:"application"`
+		BuildNeeded bool   `json:"build_needed"`
+	}
+
+	t.Run("ValidJSONInConfigOrder", func(t *testing.T) {
+		jsonOutput = true
+		defer func() { jsonOutput = false }()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		runShouldBuild(&cobra.Command{Use: "test"}, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		var entries []entry
+		if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if len(entries) != len(order) {
+			t.Fatalf("Expected %d entries, got %d: %s", len(order), len(entries), buf.String())
+		}
+		for i, name := range order {
+			if entries[i].Application != name {
+				t.Errorf("Entry %d: expected application %q, got %q", i, name, entries[i].Application)
+			}
+		}
+		// zebra exists -> no build needed; others do not -> build needed.
+		if entries[0].BuildNeeded {
+			t.Errorf("Expected zebra build_needed to be false, got true")
+		}
+		if !entries[1].BuildNeeded || !entries[2].BuildNeeded {
+			t.Errorf("Expected apple and mango build_needed to be true, got %+v", entries)
+		}
+	})
+
+	t.Run("EmptyArrayWhenNoArtifacts", func(t *testing.T) {
+		jsonOutput = true
+		oldF := filter
+		filter = "non-existent"
+		defer func() {
+			jsonOutput = false
+			filter = oldF
+		}()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		runShouldBuild(&cobra.Command{Use: "test"}, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		var entries []entry
+		if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput: %s", err, buf.String())
+		}
+		if len(entries) != 0 {
+			t.Errorf("Expected empty array, got %d entries: %s", len(entries), buf.String())
+		}
+		if strings.Contains(buf.String(), "No artifacts found") {
+			t.Errorf("JSON mode should not print 'No artifacts found', got: %s", buf.String())
+		}
+	})
 }
 
 func TestRunShouldBuild(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `--json` flag to the three table-printing commands — `artifact-names`, `hash-application`, and `should-build` — so CI pipelines can consume results programmatically instead of parsing ASCII tables.

## Changes

- `cmd/root.go`: declared a shared `jsonOutput bool` flag variable alongside the existing globals.
- Registered a `--json` bool flag on each of the three commands in their `init()` functions.
- In each run function, when `--json` is set, results are marshaled to indented JSON (`MarshalIndent`, two-space indent) in config order via a slice of structs, and printed instead of the table:
  - artifact-names: `[]{application, artifact_name}`
  - hash-application: `[]{application, hash}`
  - should-build: `[]{application, build_needed}`
- When no artifacts match, JSON mode prints an empty array `[]` instead of "No artifacts found".
- Default (non-JSON) table behavior is unchanged.

## Testing

- `gofmt -l cmd/` — clean
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — passes

Added per-command tests asserting the `--json` output is valid JSON, unmarshals into the expected slice with correct fields and config order, and emits `[]` (not the "No artifacts found" text) when empty. Tests save/restore the `jsonOutput` global to avoid leaking state.

Closes #26