### PR TITLE
Add --fail-fast and failed-build summary to do-builds

### DIFF
--- a/cmd/doBuilds.go
+++ b/cmd/doBuilds.go
@@ -35,7 +35,10 @@ import (
 	"strings"
 )
 
-var force bool
+var (
+	force    bool
+	failFast bool
+)
 
 // doBuildsCmd represents the doBuilds command
 var doBuildsCmd = &cobra.Command{
@@ -44,7 +47,9 @@ var doBuildsCmd = &cobra.Command{
 	Long: `Builds artifacts that don't exist in the repository.
 If an artifact already exists in the repository, it will not be built unless the --force flag is used.
 The command will execute the build command for each artifact, archive the output directory,
-and store the artifact in the repository.`,
+and store the artifact in the repository.
+By default it attempts every build and reports which ones failed at the end; use --fail-fast
+to stop after the first failure.`,
 	Run: runDoBuilds,
 }
 
@@ -75,6 +80,17 @@ func runDoBuilds(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Execute the builds; exit non-zero if any failed.
+	if failed := executeBuilds(artifacts, artifactConfig, repoAdapter); len(failed) > 0 {
+		os.Exit(1)
+	}
+}
+
+// executeBuilds determines which artifacts need building, runs the builds, and
+// stores the results in the repository. It prints progress and a final summary,
+// and returns the names of any artifacts that failed to build. It does not call
+// os.Exit so it can be exercised by tests.
+func executeBuilds(artifacts []slarty.ArtifactConfig, artifactConfig *slarty.ArtifactsConfig, repoAdapter slarty.RepositoryAdapter) []string {
 	// Track which artifacts need to be built
 	buildNeeded := make(map[string]bool)
 	artifactNames := make(map[string]string)
@@ -105,16 +121,16 @@ func runDoBuilds(cmd *cobra.Command, args []string) {
 		fmt.Printf("Doing build for %s - %s\n", artifact.Name, buildStatus)
 	}
 
-	// Count of successful builds
-	successfulBuilds := 0
-	totalBuildsNeeded := 0
-
 	// Count how many builds are needed
+	totalBuildsNeeded := 0
 	for _, artifact := range artifacts {
 		if buildNeeded[artifact.Name] {
 			totalBuildsNeeded++
 		}
 	}
+
+	successfulBuilds := 0
+	var failedBuilds []string
 
 	// Execute builds for artifacts that need it
 	for _, artifact := range artifacts {
@@ -125,47 +141,15 @@ func runDoBuilds(cmd *cobra.Command, args []string) {
 		fmt.Printf("\nBeginning build for %s application\n", artifact.Name)
 		fmt.Println(strings.Repeat("-", 40+len(artifact.Name)))
 
-		// Execute the build command
-		cmd := exec.Command("sh", "-c", artifact.Command)
-		cmd.Dir = artifactConfig.RootDirectory
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		err := cmd.Run()
-		if err != nil {
+		if err := buildAndStoreArtifact(artifact, artifactConfig, repoAdapter, artifactNames[artifact.Name]); err != nil {
 			fmt.Printf("Build failed for %s: %v\n", artifact.Name, err)
+			failedBuilds = append(failedBuilds, artifact.Name)
+			if failFast {
+				fmt.Println("\n-- Stopping early because --fail-fast is set")
+				break
+			}
 			continue
 		}
-
-		fmt.Printf("\n Build succeeded for %s\n", artifact.Name)
-
-		// Create a temporary tar.gz file
-		tempTarGzFile, err := os.CreateTemp("", "slarty-*.tar.gz")
-		if err != nil {
-			fmt.Printf("Failed to create temporary tar.gz file: %v\n", err)
-			continue
-		}
-		tempTarGzPath := tempTarGzFile.Name()
-		tempTarGzFile.Close() // Close the file so we can reopen it for archiving
-
-		// Archive the output directory
-		err = createTarGz(filepath.Join(artifactConfig.RootDirectory, artifact.OutputDirectory), tempTarGzPath)
-		if err != nil {
-			fmt.Printf("Failed to archive output directory: %v\n", err)
-			os.Remove(tempTarGzPath)
-			continue
-		}
-
-		// Store the artifact in the repository
-		err = repoAdapter.StoreArtifact(tempTarGzPath, artifactNames[artifact.Name])
-		if err != nil {
-			fmt.Printf("Failed to store artifact in repository: %v\n", err)
-			os.Remove(tempTarGzPath)
-			continue
-		}
-
-		// Clean up the temporary tar.gz file
-		os.Remove(tempTarGzPath)
 
 		successfulBuilds++
 
@@ -182,12 +166,54 @@ func runDoBuilds(cmd *cobra.Command, args []string) {
 		fmt.Printf("-- Saved %s to repository.\n", artifactNames[artifact.Name])
 	}
 
-	if successfulBuilds != totalBuildsNeeded {
-		fmt.Printf("\nBuilds failed for %d/%d artifacts\n", totalBuildsNeeded-successfulBuilds, totalBuildsNeeded)
-		os.Exit(1)
+	// Print a summary, listing exactly which builds failed.
+	if len(failedBuilds) > 0 {
+		fmt.Printf("\nBuilds failed for %d/%d artifacts:\n", len(failedBuilds), totalBuildsNeeded)
+		for _, name := range failedBuilds {
+			fmt.Printf(" - %s\n", name)
+		}
 	} else {
 		fmt.Printf("\nBuilds succeeded for %d artifacts\n", successfulBuilds)
 	}
+
+	return failedBuilds
+}
+
+// buildAndStoreArtifact runs an artifact's build command, archives its output
+// directory into a tar.gz, and stores the result in the repository.
+func buildAndStoreArtifact(artifact slarty.ArtifactConfig, artifactConfig *slarty.ArtifactsConfig, repoAdapter slarty.RepositoryAdapter, artifactName string) error {
+	// Execute the build command
+	cmd := exec.Command("sh", "-c", artifact.Command)
+	cmd.Dir = artifactConfig.RootDirectory
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("build command failed: %w", err)
+	}
+
+	fmt.Printf("\n Build succeeded for %s\n", artifact.Name)
+
+	// Create a temporary tar.gz file
+	tempTarGzFile, err := os.CreateTemp("", "slarty-*.tar.gz")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary tar.gz file: %w", err)
+	}
+	tempTarGzPath := tempTarGzFile.Name()
+	tempTarGzFile.Close() // Close the file so we can reopen it for archiving
+	defer os.Remove(tempTarGzPath)
+
+	// Archive the output directory
+	if err := createTarGz(filepath.Join(artifactConfig.RootDirectory, artifact.OutputDirectory), tempTarGzPath); err != nil {
+		return fmt.Errorf("failed to archive output directory: %w", err)
+	}
+
+	// Store the artifact in the repository
+	if err := repoAdapter.StoreArtifact(tempTarGzPath, artifactName); err != nil {
+		return fmt.Errorf("failed to store artifact in repository: %w", err)
+	}
+
+	return nil
 }
 
 // createTarGz archives the contents of a directory into a tar.gz file
@@ -271,4 +297,5 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	doBuildsCmd.Flags().StringVarP(&filter, "filter", "f", "", "-f \"application1,application2\"")
 	doBuildsCmd.Flags().BoolVarP(&force, "force", "", false, "Force build even if artifact exists")
+	doBuildsCmd.Flags().BoolVar(&failFast, "fail-fast", false, "Stop after the first failed build")
 }

--- a/cmd/doBuilds_test.go
+++ b/cmd/doBuilds_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dstockto/slarty/slarty"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +44,150 @@ func TestDoBuildsCommandFlags(t *testing.T) {
 	// Check force flag
 	if flags.Lookup("force") == nil {
 		t.Error("do-builds command should have 'force' flag")
+	}
+
+	// Check fail-fast flag
+	if flags.Lookup("fail-fast") == nil {
+		t.Error("do-builds command should have 'fail-fast' flag")
+	}
+}
+
+// buildTestSetup creates a temporary git repo with the given artifacts JSON
+// fragment and the given (root-relative) directories, then returns a config and
+// a local repository adapter ready for executeBuilds. The temp dir is cleaned up
+// automatically.
+func buildTestSetup(t *testing.T, artifactsJSON string, dirs []string) (*slarty.ArtifactsConfig, slarty.RepositoryAdapter) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "slarty-do-builds-fail-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	repoDir := filepath.Join(tempDir, "repo")
+	if err := os.Mkdir(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create repo directory: %v", err)
+	}
+
+	for _, d := range dirs {
+		full := filepath.Join(tempDir, d)
+		if err := os.MkdirAll(full, 0755); err != nil {
+			t.Fatalf("Failed to create dir %s: %v", d, err)
+		}
+		if err := os.WriteFile(filepath.Join(full, "f.txt"), []byte(d), 0644); err != nil {
+			t.Fatalf("Failed to write file in %s: %v", d, err)
+		}
+	}
+
+	jsonContent := `{
+		"application": "Test App",
+		"root_directory": "` + tempDir + `",
+		"repository": { "adapter": "Local", "options": { "root": "` + repoDir + `" } },
+		"artifacts": [` + artifactsJSON + `]
+	}`
+	configPath := filepath.Join(tempDir, "artifacts.json")
+	if err := os.WriteFile(configPath, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	runGit := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = tempDir
+		if err := c.Run(); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test User")
+	runGit("add", ".")
+	runGit("commit", "-m", "Initial commit")
+
+	config, err := slarty.ReadArtifactsJson(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	repo, err := slarty.NewRepositoryAdapter(config, true)
+	if err != nil {
+		t.Fatalf("Failed to create repository adapter: %v", err)
+	}
+	return config, repo
+}
+
+// captureExecuteBuilds runs executeBuilds with stdout captured, returning the
+// failed-artifact slice and the captured output.
+func captureExecuteBuilds(t *testing.T, config *slarty.ArtifactsConfig, repo slarty.RepositoryAdapter) ([]string, string) {
+	t.Helper()
+	artifacts := config.GetByArtifactsByNameWithFilter(nil)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	failed := executeBuilds(artifacts, config, repo)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return failed, buf.String()
+}
+
+func TestExecuteBuildsReportsFailures(t *testing.T) {
+	artifacts := `
+		{ "name": "good", "directories": ["src/good"], "command": "echo built", "output_directory": "build/good", "deploy_location": "deploy/good", "artifact_prefix": "good" },
+		{ "name": "bad", "directories": ["src/bad"], "command": "exit 1", "output_directory": "build/bad", "deploy_location": "deploy/bad", "artifact_prefix": "bad" }`
+	config, repo := buildTestSetup(t, artifacts, []string{"src/good", "src/bad", "build/good", "build/bad"})
+
+	oldForce, oldFailFast := force, failFast
+	defer func() { force, failFast = oldForce, oldFailFast }()
+	force = true // build regardless of repo state
+	failFast = false
+
+	failed, output := captureExecuteBuilds(t, config, repo)
+
+	if len(failed) != 1 || failed[0] != "bad" {
+		t.Fatalf("Expected failed=[bad], got %v", failed)
+	}
+	if !strings.Contains(output, "Build failed for bad") {
+		t.Errorf("Expected failure message for bad, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Builds failed for 1/2 artifacts:") {
+		t.Errorf("Expected failure summary, got:\n%s", output)
+	}
+	if !strings.Contains(output, "- bad") {
+		t.Errorf("Expected summary to list bad, got:\n%s", output)
+	}
+	// The good artifact should still have been built and stored despite bad failing.
+	if !strings.Contains(output, "Build succeeded for good") {
+		t.Errorf("Expected good to build, got:\n%s", output)
+	}
+}
+
+func TestExecuteBuildsFailFastStopsEarly(t *testing.T) {
+	artifacts := `
+		{ "name": "bad1", "directories": ["src/bad1"], "command": "exit 1", "output_directory": "build/bad1", "deploy_location": "d/bad1", "artifact_prefix": "bad1" },
+		{ "name": "bad2", "directories": ["src/bad2"], "command": "echo SHOULD_NOT_RUN_BAD2", "output_directory": "build/bad2", "deploy_location": "d/bad2", "artifact_prefix": "bad2" }`
+	config, repo := buildTestSetup(t, artifacts, []string{"src/bad1", "src/bad2", "build/bad1", "build/bad2"})
+
+	oldForce, oldFailFast := force, failFast
+	defer func() { force, failFast = oldForce, oldFailFast }()
+	force = true
+	failFast = true
+
+	failed, output := captureExecuteBuilds(t, config, repo)
+
+	if len(failed) != 1 || failed[0] != "bad1" {
+		t.Fatalf("Expected failed=[bad1] with fail-fast, got %v", failed)
+	}
+	if !strings.Contains(output, "Stopping early because --fail-fast is set") {
+		t.Errorf("Expected fail-fast notice, got:\n%s", output)
+	}
+	// The second artifact must never have started building.
+	if strings.Contains(output, "Beginning build for bad2") || strings.Contains(output, "SHOULD_NOT_RUN_BAD2") {
+		t.Errorf("fail-fast did not stop before bad2, got:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

`do-builds` previously attempted every needed build and reported only a *count* of failures (`Builds failed for N/M artifacts`), so CI logs didn't show *which* artifacts failed. It also had no way to stop early on the first failure.

## Changes

- Add a `--fail-fast` flag that stops after the first failed build.
- The end-of-run summary now lists exactly which artifacts failed, by name.
- Refactor the build loop into a testable `executeBuilds` helper (and a `buildAndStoreArtifact` helper); the `os.Exit(1)` now lives only in the thin cobra `Run` wrapper, so the build logic can be unit tested without terminating the test process.
- Default behavior is unchanged: without `--fail-fast`, every build is still attempted and the command exits non-zero if any failed.

## Testing

- `gofmt -l cmd/` clean, `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- New tests: `TestExecuteBuildsReportsFailures` (a failing build is listed in the summary while a good build still completes) and `TestExecuteBuildsFailFastStopsEarly` (the second artifact never starts once `--fail-fast` trips), plus a flag-presence check.

Closes #20